### PR TITLE
Conversion from bytes to concentration

### DIFF
--- a/sds-reader.py
+++ b/sds-reader.py
@@ -40,8 +40,8 @@ class SDS011Reader:
 
                 elif step>8:
                     step =0
-                    pm25 = values[0]+values[1]*256
-                    pm10 = values[2]+values[3]*256
+                    pm25 = (values[0]+values[1]*256)/10
+                    pm10 = (values[2]+values[3]*256)/10
                     return [pm25,pm10]
 
                 elif step>=2:


### PR DESCRIPTION
https://ecksteinimg.de/Datasheet/SDS018%20Laser%20PM2.5%20Product%20Spec%20V1.5.pdf the formula page 7 of the datasheet says that the bytes should be divided by 10 to give the correct concentrations.